### PR TITLE
Changed message and event Redis storing method

### DIFF
--- a/server/src/services/eventService.ts
+++ b/server/src/services/eventService.ts
@@ -4,17 +4,26 @@ import {serverEventSchema, type ServerEvent} from '../validators/ServerEvent';
 const redisKey = 'events';
 
 const cache = async (event: ServerEvent) => {
-	await redis.client.multi()
-		.rPush(redisKey, JSON.stringify(event))
-		.expire(redisKey, 60 * 60) // 1 hour in seconds
-		.exec();
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	await redis.client.set(`${redisKey}:${event.timestamp.valueOf()}`, JSON.stringify(event), {EX: 60 * 60}); // Set to expire in 1 hour
 };
 
 const getAllCached = async () => {
-	const events = await redis.client.lRange(redisKey, 0, -1);
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	const {keys} = await redis.client.scan(0, {MATCH: `${redisKey}:*`, COUNT: 1000});
+
+	if (keys.length === 0) {
+		return [];
+	}
+
+	const events = await redis.client.mGet(keys);
 
 	const parsedEvents = events
 		.map(unparsedEvent => {
+			if (!unparsedEvent) {
+				return null;
+			}
+
 			const parseResults = serverEventSchema.safeParse(JSON.parse(unparsedEvent));
 
 			return parseResults.success ? parseResults.data : null;


### PR DESCRIPTION
Instead of storing messages in a list that has a shared TTL, now storing them under separate keys. This allows single messages to expire even when new messages are constantly stored.

When using Redis this way, all existing and matching keys need to be scanned first and only then fetched.